### PR TITLE
Fix system metrics tile text visibility

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -195,16 +195,20 @@ body{
 }
 #bgOverlay, #bgOverlay::before { z-index: 0; }
 #wrap { position: relative; z-index: 1; }
-#sysTile { position: relative; z-index: 2; color: var()white; }
+#sysTile {
+  position: relative;
+  z-index: 2;
+  color: #fff;
+}
 
-#sysTile, #sysTile span {
-  color: #fff !important;
-  opacity: 1 !important;
-  visibility: visible !important;
-  mix-blend-mode: normal !important;
-  filter: none !important;
-  text-shadow: 0 1px 2px rgba(0,0,0,.25); /* nur für Kontrast */
-  font-size: 16px;                         /* falls irgendwo 0 gesetzt wurde */
+#sysTile span {
+  color: #fff;
+  opacity: 1;
+  visibility: visible;
+  mix-blend-mode: normal;
+  filter: none;
+  text-shadow: 0 1px 2px rgba(0,0,0,.25);
+  font-size: 16px;
 }
 
 :root{

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,13 +67,13 @@
       </section>
 
       <!-- Slide 1: System -->
-      <section class="dash" id="sysDash">
-        <div class="tiles">
-          <div class="tile" id="sysTile">
-            <span id="cpu">—%</span>  <span id="ram">—%</span>  <span id="temp">—°C</span>
+        <section class="dash" id="sysDash">
+          <div class="tiles">
+            <div class="tile" id="sysTile">
+              CPU: <span id="cpu">—%</span>&nbsp; RAM: <span id="ram">—%</span>&nbsp; Temp: <span id="temp">—°C</span>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
 
       <!-- Slide 2: Pi-hole -->
       <section class="dash" id="piDash">


### PR DESCRIPTION
## Summary
- Show CPU, RAM and temperature labels in system dashboard tile
- Simplify system tile CSS to ensure metric text is visible

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689a5c121da08332b8d0f536b958747f