### PR TITLE
Fix system stats visibility on carousel

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -20,23 +20,18 @@ document.addEventListener("DOMContentLoaded", ()=> {
     setInterval(tick, 1000);
 
     // System-Kachel (CPU/RAM/Temperatur)
-    const systInterval = initSystem({
+    initSystem({
         cpuEl: el("cpu"),
         ramEl: el("ram"),
         tempEl: el("temp"),
-        containerEl: el("sysDash"),
         pollMs: 6000,
     });
 
-    //Swipe Carousel zum wechseln der Dashboards
+    // Swipe-Carousel zum Wechseln der Dashboards
     const dots = Array.from(document.querySelectorAll("#pager .dot"));
     const carousel = initSwipe({
         wrapEl: el("dashWrap"),
         dots,
-        onChange: (i) => {
-    if (i === 1) systInterval.start();    // Slide 1 = System
-    else         systInterval.stop();
-  }
     });
 
     //spotify player:


### PR DESCRIPTION
## Summary
- Start polling system metrics immediately so CPU/RAM data is ready when switching to the system page
- Simplify carousel setup by removing redundant visibility callback

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689a5e47b6108332956983ced6123495