### PR TITLE
Center system stats display

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -195,20 +195,21 @@ body{
 }
 #bgOverlay, #bgOverlay::before { z-index: 0; }
 #wrap { position: relative; z-index: 1; }
-#sysTile {
-  position: relative;
-  z-index: 2;
-  color: #fff;
+#sysDash {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
-#sysTile span {
+#sysCenter {
+  text-align: center;
   color: #fff;
-  opacity: 1;
-  visibility: visible;
-  mix-blend-mode: normal;
-  filter: none;
-  text-shadow: 0 1px 2px rgba(0,0,0,.25);
-  font-size: 16px;
+  font-size: 48px;
+  line-height: 1.2;
+}
+
+#sysCenter .sysLine {
+  margin: 10px 0;
 }
 
 :root{

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,13 +67,13 @@
       </section>
 
       <!-- Slide 1: System -->
-        <section class="dash" id="sysDash">
-          <div class="tiles">
-            <div class="tile" id="sysTile">
-              CPU: <span id="cpu">—%</span>&nbsp; RAM: <span id="ram">—%</span>&nbsp; Temp: <span id="temp">—°C</span>
-            </div>
-          </div>
-        </section>
+      <section class="dash" id="sysDash">
+        <div id="sysCenter">
+          <div class="sysLine">CPU: <span id="cpu">—%</span></div>
+          <div class="sysLine">RAM: <span id="ram">—%</span></div>
+          <div class="sysLine">Temp: <span id="temp">—°C</span></div>
+        </div>
+      </section>
 
       <!-- Slide 2: Pi-hole -->
       <section class="dash" id="piDash">


### PR DESCRIPTION
## Summary
- Center CPU, RAM, and temperature stats and enlarge in white text
- Add supporting CSS for centered layout and large font

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a60564c1c83328b1dbd85369ff846