### PR TITLE
Move stats and placeholder to system slide

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -24,6 +24,7 @@ document.addEventListener("DOMContentLoaded", ()=> {
         cpuEl: el("cpu"),
         ramEl: el("ram"),
         tempEl: el("temp"),
+        containerEl: el("sysDash"),
         pollMs: 6000,
     });
 

--- a/static/style.css
+++ b/static/style.css
@@ -193,9 +193,12 @@ body{
   padding: .7rem .9rem; border-radius: var(--radius);
   box-shadow: 0 6px 20px rgba(0,0,0,.25);
 }
-#bgOverlay, #bgOverlay::before { z-index: 0; }
+
+#bg, #bgOverlay, #bgOverlay::before { z-index: -1; }
 #wrap { position: relative; z-index: 1; }
 #sysDash {
+  position: relative;
+  z-index: 1;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -206,6 +209,14 @@ body{
   color: #fff;
   font-size: 48px;
   line-height: 1.2;
+}
+
+#sysCenter input {
+  background: var(--card);
+  color: var(--fg);
+  border: none;
+  border-radius: var(--radius);
+  padding: .4rem .6rem;
 }
 
 #sysCenter .sysLine {

--- a/templates/index.html
+++ b/templates/index.html
@@ -72,6 +72,7 @@
           <div class="sysLine">CPU: <span id="cpu">—%</span></div>
           <div class="sysLine">RAM: <span id="ram">—%</span></div>
           <div class="sysLine">Temp: <span id="temp">—°C</span></div>
+          <input type="text" placeholder="Lorem ipsum dolor sit amet, consectetuer">
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Display CPU, RAM and temperature stats exclusively on the second slide with a 40-character lorem ipsum placeholder input
- Ensure system slide text and input sit above the background and are styled for visibility
- Poll system metrics only when the system slide is visible to avoid unnecessary API calls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a6d2ef3c08332b158a90e32f08865