### PR TITLE
Fix dashboard layering with non-negative z-index

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -194,11 +194,19 @@ body{
   box-shadow: 0 6px 20px rgba(0,0,0,.25);
 }
 
-#bg, #bgOverlay, #bgOverlay::before { z-index: -1; }
-#wrap { position: relative; z-index: 1; }
+#bg,
+#bgOverlay,
+#bgOverlay::before {
+  z-index: 0;          /* background base */
+}
+
+#wrap,
 #sysDash {
   position: relative;
-  z-index: 1;
+  z-index: 10;         /* content above background */
+}
+
+#sysDash {
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Summary
- Set background layers to z-index 0
- Raise wrap and dashboard sections to z-index 10 so CPU/RAM lines and placeholder are visible

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b3444adfc8332905e49366d93bdad