### PR TITLE
Fix carousel width calculation

### DIFF
--- a/static/js/gestures.js
+++ b/static/js/gestures.js
@@ -2,7 +2,7 @@
 export function initSwipe({ wrapEl, dots, onChange }) {
   const slides = Array.from(wrapEl.children);
   let idx = 0, start = 0, vX = 0, lastX = 0, lastT = 0, drag = false;
-  const w = () => wrapEl.clientWidth, THRESH = 0.18, MAXV = 2;
+  const w = () => slides[0]?.clientWidth || wrapEl.clientWidth, THRESH = 0.18, MAXV = 2;
 
   const setX = (px, animate) => {
     wrapEl.classList.toggle("swipe-anim", !!animate);


### PR DESCRIPTION
## Summary
- use slide width instead of wrap width for carousel translation to prevent overshooting when swiping

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5a1999d2c83328d7f43daa167a94d