### PR TITLE
Fix carousel slide width calculation

### DIFF
--- a/static/js/gestures.js
+++ b/static/js/gestures.js
@@ -2,7 +2,8 @@
 export function initSwipe({ wrapEl, dots, onChange }) {
   const slides = Array.from(wrapEl.children);
   let idx = 0, start = 0, vX = 0, lastX = 0, lastT = 0, drag = false;
-  const w = () => wrapEl.clientWidth, THRESH = 0.18, MAXV = 2;
+  // width of a single slide (wrapEl is the combined width of all slides)
+  const w = () => wrapEl.clientWidth / slides.length, THRESH = 0.18, MAXV = 2;
 
   const setX = (px, animate) => {
     wrapEl.classList.toggle("swipe-anim", !!animate);


### PR DESCRIPTION
## Summary
- correct slide width calculation in `gestures.js` so carousel translates by single-slide width

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5a1999d2c83328d7f43daa167a94d