### PR TITLE
Start system metrics polling immediately and add IntersectionObserver fallback

### DIFF
--- a/static/js/system.js
+++ b/static/js/system.js
@@ -41,15 +41,24 @@ export function initSystem({ cpuEl, ramEl, tempEl, containerEl, pollMs = 6000 })
 
   // Optional: Sichtbarkeit via Viewport (funktioniert auch mit transform)
   if (containerEl) {
-    const io = new IntersectionObserver(
-      (entries) => {
-        const e = entries[0];
-        const isVis = e.isIntersecting && e.intersectionRatio >= 0.6;
-        isVis ? start() : stop();
-      },
-      { root: null, threshold: [0, 0.6, 1] }
-    );
-    io.observe(containerEl);
+    // Fallback: falls der Browser keinen IntersectionObserver kennt
+    if (typeof window !== "undefined" && "IntersectionObserver" in window) {
+      const io = new IntersectionObserver(
+        (entries) => {
+          const e = entries[0];
+          const isVis = e.isIntersecting && e.intersectionRatio >= 0.6;
+          isVis ? start() : stop();
+        },
+        { root: null, threshold: [0, 0.6, 1] }
+      );
+      io.observe(containerEl);
+
+      // Einmalig starten, damit beim ersten Besuch Werte sichtbar sind
+      start();
+    } else {
+      // Kein IntersectionObserver vorhanden -> direkt starten
+      start();
+    }
   } else {
     start();
   }


### PR DESCRIPTION
## Summary
- Start system stats polling right after setting up IntersectionObserver for quicker initial load
- Add fallback to start polling when IntersectionObserver is unavailable

## Testing
- `node --check static/js/system.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5a7348d348332a773e1145cd62d92