### PR TITLE
Default to system dashboard

### DIFF
--- a/static/js/gestures.js
+++ b/static/js/gestures.js
@@ -1,5 +1,5 @@
 // gestures.js
-export function initSwipe({ wrapEl, dots, onChange }) {
+export function initSwipe({ wrapEl, dots, onChange, startIndex = 0 }) {
   const slides = Array.from(wrapEl.children);
   let idx = 0, start = 0, vX = 0, lastX = 0, lastT = 0, drag = false;
   // width of a single slide (wrapEl is the combined width of all slides)
@@ -78,6 +78,6 @@ export function initSwipe({ wrapEl, dots, onChange }) {
   }
 
   // Start
-  snap(0, false);
+  snap(startIndex, false);
   return { next: () => snap(idx + 1), prev: () => snap(idx - 1), go: (i) => snap(i) };
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -26,6 +26,7 @@ document.addEventListener("DOMContentLoaded", ()=> {
     const carousel = initSwipe({
         wrapEl: el("dashWrap"),
         dots,
+        startIndex: 1,
     });
 
     //spotify player:


### PR DESCRIPTION
## Summary
- allow `initSwipe` to take a `startIndex` so a specific slide can be loaded first
- initialize the carousel on the system dashboard to keep sys info visible during tests

## Testing
- `python -m py_compile app.py`
- `node --check static/js/gestures.js`
- `node --check static/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5af52fe7c8332b8f52b1ad022b181