### PR TITLE
Simplify system widget visibility observer

### DIFF
--- a/static/js/system.js
+++ b/static/js/system.js
@@ -40,28 +40,20 @@ export function initSystem({ cpuEl, ramEl, tempEl, containerEl, pollMs = 6000 })
   }
 
   // Optional: Sichtbarkeit via Viewport (funktioniert auch mit transform)
-  if (containerEl) {
-    // Fallback: falls der Browser keinen IntersectionObserver kennt
-    if (typeof window !== "undefined" && "IntersectionObserver" in window) {
-      const io = new IntersectionObserver(
-        (entries) => {
-          const e = entries[0];
-          const isVis = e.isIntersecting && e.intersectionRatio >= 0.6;
-          isVis ? start() : stop();
-        },
-        { root: null, threshold: [0, 0.6, 1] }
-      );
-      io.observe(containerEl);
-
-      // Einmalig starten, damit beim ersten Besuch Werte sichtbar sind
-      start();
-    } else {
-      // Kein IntersectionObserver vorhanden -> direkt starten
-      start();
-    }
-  } else {
-    start();
+  if (containerEl && typeof window !== "undefined" && "IntersectionObserver" in window) {
+    const io = new IntersectionObserver(
+      (entries) => {
+        const e = entries[0];
+        const isVis = e.isIntersecting;
+        isVis ? start() : stop();
+      },
+      { root: null, threshold: [0, 0.1, 1] }
+    );
+    io.observe(containerEl);
   }
+
+  // Ensure initial values are populated
+  start();
 
   return { start, stop, refresh };
 }


### PR DESCRIPTION
## Summary
- Simplify visibility check to just `isIntersecting`
- Update IntersectionObserver thresholds to `[0, 0.1, 1]`
- Start polling immediately on load so first refresh populates the DOM

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5b30db2d4833288410b96970656b8