### PR TITLE
Simplify system widget visibility observer

### DIFF
--- a/static/js/system.js
+++ b/static/js/system.js
@@ -15,13 +15,9 @@ export function initSystem({ cpuEl, ramEl, tempEl, containerEl, pollMs = 6000 })
       if (!visible) return;
       const s = await jget("/api/system");
 
-  if (Number.isFinite(s.cpu_pct) && cpuEl) cpuEl.textContent = Math.round(s.cpu_pct) + "%";
-  if (Number.isFinite(s.ram_pct) && ramEl) ramEl.textContent = Math.round(s.ram_pct) + "%";
-
-  if (tempEl) {
-    if (Number.isFinite(s.temp_c)) tempEl.textContent = s.temp_c.toFixed(1) + "°C";
-    else tempEl.textContent = "—";            // oder: tempEl.parentElement?.classList.add('hidden')
-  }
+      setCPU(s.cpu_pct);
+      setRAM(s.ram_pct);
+      setTEMP(s.temp_c);
     } catch (e) {
       console.warn("[system] failed", e);
     }
@@ -40,28 +36,20 @@ export function initSystem({ cpuEl, ramEl, tempEl, containerEl, pollMs = 6000 })
   }
 
   // Optional: Sichtbarkeit via Viewport (funktioniert auch mit transform)
-  if (containerEl) {
-    // Fallback: falls der Browser keinen IntersectionObserver kennt
-    if (typeof window !== "undefined" && "IntersectionObserver" in window) {
-      const io = new IntersectionObserver(
-        (entries) => {
-          const e = entries[0];
-          const isVis = e.isIntersecting && e.intersectionRatio >= 0.6;
-          isVis ? start() : stop();
-        },
-        { root: null, threshold: [0, 0.6, 1] }
-      );
-      io.observe(containerEl);
-
-      // Einmalig starten, damit beim ersten Besuch Werte sichtbar sind
-      start();
-    } else {
-      // Kein IntersectionObserver vorhanden -> direkt starten
-      start();
-    }
-  } else {
-    start();
+  if (containerEl && typeof window !== "undefined" && "IntersectionObserver" in window) {
+    const io = new IntersectionObserver(
+      (entries) => {
+        const e = entries[0];
+        const isVis = e.isIntersecting;
+        isVis ? start() : stop();
+      },
+      { root: null, threshold: [0, 0.1, 1] }
+    );
+    io.observe(containerEl);
   }
+
+  // Ensure initial values are populated
+  start();
 
   return { start, stop, refresh };
 }


### PR DESCRIPTION
## Summary
- Use `isIntersecting` for visibility checks and set thresholds to `[0, 0.1, 1]`
- Start system polling immediately so the first refresh populates the DOM
- Restore helper setters for safe DOM updates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5b30db2d4833288410b96970656b8