### PR TITLE
Fix carousel slide transition glitch

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -76,18 +76,6 @@ body{
   flex: 0 0 100%;
 }
 
-.dash{
-  display:none;
-  width:100%;
-  padding: 8px;
-}
-.dash.active{
-  display:block;
-}
-
-
-
-
 /* ===== Player ===== */
 .eq {
   /* dynamisch via JS */


### PR DESCRIPTION
## Summary
- prevent slide collapse in carousel by keeping all slides visible during transitions

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6369a453883328bfb410f649e8487