### PR TITLE
feat: add looping carousel

### DIFF
--- a/static/js/gestures.js
+++ b/static/js/gestures.js
@@ -1,56 +1,75 @@
 // gestures.js
-// Simple carousel that toggles between full-width pages.
+// Enhanced swipe carousel with wrap-around navigation.
 export function initSwipe({ wrapEl, dots, onChange, startIndex = 0 }) {
-  const slides = Array.from(wrapEl.children);
-  let idx = startIndex;
+  // Collect original slides and create clones for seamless looping
+  const origSlides = Array.from(wrapEl.children);
+  const count = origSlides.length;
+
+  const firstClone = origSlides[0].cloneNode(true);
+  const lastClone = origSlides[count - 1].cloneNode(true);
+  wrapEl.appendChild(firstClone);
+  wrapEl.insertBefore(lastClone, wrapEl.firstChild);
+
+  const slides = Array.from(wrapEl.children); // includes clones
+  let idx = startIndex + 1; // account for leading clone
   const THRESH = 50;
 
-  // Show a specific slide and hide the others
-  const show = (i) => {
-    idx = Math.max(0, Math.min(i, slides.length - 1));
-    slides.forEach((s, j) => {
-      s.classList.toggle("active", j === idx);
-    });
-
-    wrapEl.style.transform = `translateX(-${idx * 100}%)`;
-
-    if (dots?.length) {
-      dots.forEach((d, j) => d.classList.toggle("active", j === idx));
-    }
-
-    if (typeof onChange === "function") onChange(idx);
+  const updateDots = (realIdx) => {
+    if (!dots?.length) return;
+    dots.forEach((d, j) => d.classList.toggle("active", j === realIdx));
   };
 
-  // Basic swipe handling – detect horizontal swipe on release
+  // Show slide by internal index (includes clones)
+  const show = (i, { animate = true } = {}) => {
+    idx = i;
+    if (!animate) wrapEl.style.transition = "none";
+
+    slides.forEach((s, j) => s.classList.toggle("active", j === idx));
+    wrapEl.style.transform = `translateX(-${idx * 100}%)`;
+
+    const realIdx = (idx - 1 + count) % count;
+    updateDots(realIdx);
+    if (typeof onChange === "function") onChange(realIdx);
+
+    if (!animate) requestAnimationFrame(() => (wrapEl.style.transition = ""));
+  };
+
+  // After sliding onto a clone, jump to the real slide without animation
+  wrapEl.addEventListener("transitionend", () => {
+    if (idx === 0) show(count, { animate: false });
+    else if (idx === count + 1) show(1, { animate: false });
+  });
+
+  // Touch handling
   let startX = 0, dragging = false;
-  wrapEl.addEventListener("touchstart", e => {
+  wrapEl.addEventListener("touchstart", (e) => {
     if (e.touches.length !== 1) return;
     dragging = true;
     startX = e.touches[0].clientX;
   }, { passive: true });
 
-  wrapEl.addEventListener("touchend", e => {
+  wrapEl.addEventListener("touchend", (e) => {
     if (!dragging) return;
     dragging = false;
     const dx = e.changedTouches[0].clientX - startX;
     if (Math.abs(dx) > THRESH) show(idx + (dx < 0 ? 1 : -1));
   }, { passive: true });
 
-  // Bind dot navigation
+  // Dot navigation (real slide indices)
   if (dots?.length) {
-    dots.forEach((d, i) => d.addEventListener("click", e => {
+    dots.forEach((d, i) => d.addEventListener("click", (e) => {
       e.preventDefault(); e.stopPropagation();
-      show(i);
+      show(i + 1);
     }));
   }
 
-
-  show(startIndex);
+  // Initialize
+  show(startIndex + 1, { animate: false });
 
   return {
     next: () => show(idx + 1),
     prev: () => show(idx - 1),
-    go: (i) => show(i)
+    go: (i) => show(i + 1),
   };
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -29,18 +29,6 @@ document.addEventListener("DOMContentLoaded", ()=> {
         pollMs: 6000,
     });
 
-    // Swipe-Carousel zum Wechseln der Dashboards
-    const dots = Array.from(document.querySelectorAll("#pager .dot"));
-    const carousel = initSwipe({
-        wrapEl: el("dashWrap"),
-        dots,
-        startIndex: 1,
-        onChange: (i) => {
-            if (i === 1) system.start();
-            else system.stop();
-        },
-    });
-
     //spotify player:
     const player = initPlayer({
         coverEl: el("cover"),
@@ -61,6 +49,18 @@ document.addEventListener("DOMContentLoaded", ()=> {
         pollMs: 1000,
     });
     //Debug: window.Player = player;
+
+    // Swipe-Carousel zum Wechseln der Dashboards
+    const dots = Array.from(document.querySelectorAll("#pager .dot"));
+    const carousel = initSwipe({
+        wrapEl: el("dashWrap"),
+        dots,
+        startIndex: 1,
+        onChange: (i) => {
+            if (i === 1) system.start();
+            else system.stop();
+        },
+    });
 
 
     // hier weitere Module einfügen:

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,7 +34,7 @@
     </nav>
 
     <!-- Swipe-Container mit 4 Seiten -->
-    <div id="dashWrap" aria-roledescription="carousel" style="transform:translateX(-100%)">
+    <div id="dashWrap" aria-roledescription="carousel">
       <!-- Slide 0: Now Playing -->
       <section class="dash" id="dash-now">
         <div id="player">


### PR DESCRIPTION
## Summary
- enable seamless looping carousel navigation
- initialize swipe logic after player setup to keep IDs stable
- clean up dashboard markup for new carousel logic

## Testing
- `node --check static/js/main.js`
- `node --check static/js/gestures.js`
- `python -m py_compile app.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7056512a483328f3e3fcedf99dd56