### PR TITLE
Fix touch/pointer activation for carousel dots and player controls

### DIFF
--- a/static/js/gestures.js
+++ b/static/js/gestures.js
@@ -55,12 +55,32 @@ export function initSwipe({ wrapEl, dots, onChange, startIndex = 0 }) {
     if (Math.abs(dx) > THRESH) show(idx + (dx < 0 ? 1 : -1));
   }, { passive: true });
 
+  const bindActivate = (el, fn) => {
+    if (!el || typeof fn !== "function") return;
+    let pointerHandled = false;
+
+    el.addEventListener("pointerup", (e) => {
+      if (e.pointerType === "mouse" && e.button !== 0) return;
+      pointerHandled = true;
+      e.preventDefault();
+      e.stopPropagation();
+      fn(e);
+    });
+
+    el.addEventListener("click", (e) => {
+      if (pointerHandled) {
+        pointerHandled = false;
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      fn(e);
+    });
+  };
+
   // Dot navigation (real slide indices)
   if (dots?.length) {
-    dots.forEach((d, i) => d.addEventListener("click", (e) => {
-      e.preventDefault(); e.stopPropagation();
-      show(i + 1);
-    }));
+    dots.forEach((d, i) => bindActivate(d, () => show(i + 1)));
   }
 
   // Initialize
@@ -72,4 +92,3 @@ export function initSwipe({ wrapEl, dots, onChange, startIndex = 0 }) {
     go: (i) => show(i + 1),
   };
 }
-

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -17,6 +17,26 @@ export function initPlayer({
   eqTextEl, eqTopEl,
   pollMs = 1000,
 }) {
+  const bindActivate = (el, fn) => {
+    if (!el || typeof fn !== "function") return;
+    let pointerHandled = false;
+
+    el.addEventListener("pointerup", (e) => {
+      if (e.pointerType === "mouse" && e.button !== 0) return;
+      pointerHandled = true;
+      e.preventDefault();
+      fn(e);
+    });
+
+    el.addEventListener("click", (e) => {
+      if (pointerHandled) {
+        pointerHandled = false;
+        return;
+      }
+      fn(e);
+    });
+  };
+
   // ---- State ----
   let trackId = null;
   let durationMs = 0;
@@ -206,17 +226,30 @@ export function initPlayer({
   }
 
   // ---- Events ----
-  btnPlayEl?.addEventListener("click", toggle);
-  btnPrevEl?.addEventListener("click", prev);   // <— Funktionsreferenz!
-  btnNextEl?.addEventListener("click", next);   // <— Funktionsreferenz!
+  bindActivate(btnPlayEl, toggle);
+  bindActivate(btnPrevEl, prev);
+  bindActivate(btnNextEl, next);
 
   if (progressWrapEl && progressBarEl) {
-    progressWrapEl.addEventListener("click", (e) => {
+    let progressPointerHandled = false;
+    const onProgress = (e) => {
       if (!controlsArmed() || !readyToSeek) return;
       const rect = progressWrapEl.getBoundingClientRect();
       const x = e.clientX - rect.left;
       const ratio = rect.width > 0 ? x / rect.width : 0;
       seekTo(ratio);
+    };
+
+    progressWrapEl.addEventListener("pointerup", (e) => {
+      progressPointerHandled = true;
+      onProgress(e);
+    });
+    progressWrapEl.addEventListener("click", (e) => {
+      if (progressPointerHandled) {
+        progressPointerHandled = false;
+        return;
+      }
+      onProgress(e);
     }, { passive: true });
   }
 


### PR DESCRIPTION
### Motivation
- Buttons and pager dots were non-responsive on touch/kiosk devices because the UI relied only on `click`, which can be delayed or dropped on some platforms. 
- The progress/seek bar also needed pointer-aware handling to make seeking reliable with touch.

### Description
- Add a shared `bindActivate` helper that listens for `pointerup` and `click` and suppresses duplicate events, and apply it to pager dots in `static/js/gestures.js`.
- Use the same `bindActivate` helper for the player controls (`btnPlay`, `btnPrev`, `btnNext`) in `static/js/player.js` so play/prev/next respond reliably to touch and mouse.
- Update the progress/seek interaction to handle `pointerup` in addition to `click` and de-duplicate the two event paths to avoid double triggers.
- Include conservative guards (ignore non-primary mouse buttons) and preserve existing behavior such as the control arming grace period.

### Testing
- Ran `node --check static/js/gestures.js` and it completed successfully.
- Ran `node --check static/js/player.js` and it completed successfully.
- Previously validated with `node --check static/js/main.js` and `python -m py_compile app.py`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf2bc738083329d50bc4475470264)